### PR TITLE
Fixes functions os.listdirs and os.listfiles for argument `""`

### DIFF
--- a/lua-functions.cc
+++ b/lua-functions.cc
@@ -25,7 +25,7 @@ int listDirectoryFull(lua_State *L, int mode) {
 		return 1;
 	}
 
-	int index = 0;
+	int index = 1;
 	do {
 		if(strcmp(fdFile.cFileName, ".") == 0 || strcmp(fdFile.cFileName, "..") == 0)
 			continue;

--- a/lua-functions.cc
+++ b/lua-functions.cc
@@ -20,7 +20,7 @@ int listDirectoryFull(lua_State *L, int mode) {
 	WIN32_FIND_DATAA fdFile;
 	HANDLE handle = NULL;
 
-	std::string path = format("%s\\*.*", dirname);
+	std::string path = format(".\\%s\\*.*", dirname);
 	if((handle = FindFirstFileA(path.c_str(), &fdFile)) == INVALID_HANDLE_VALUE) {
 		return 1;
 	}


### PR DESCRIPTION
Changes os.listdirs and os.listfiles, when given the argument `""`; to return files and directories from the install directory of Into the breach, instead of from the root of the disk drive.