### PR TITLE
Added event textinput

### DIFF
--- a/lua-functions.cc
+++ b/lua-functions.cc
@@ -73,6 +73,7 @@ namespace event{
 	int mousebuttondown = SDL_MOUSEBUTTONDOWN;
 	int mousebuttonup = SDL_MOUSEBUTTONUP;
 	int mousewheel = SDL_MOUSEWHEEL;
+	int textinput = SDL_TEXTINPUT;
 }
 
 struct DrawHook :public SDL::DrawHook {
@@ -263,6 +264,7 @@ void installFunctions(lua_State *L) {
 		.addFunction("y", &SDL::Event::y)
 		.addFunction("wheel", &SDL::Event::wheely)
 		.addFunction("keycode", &SDL::Event::keycode)
+		.addCFunction("textinput", &SDL::Event::textinput)
 		.addFunction("mousebutton", &SDL::Event::mousebutton)
 		.endClass()
 
@@ -295,6 +297,7 @@ void installFunctions(lua_State *L) {
 		.addVariable("mousebuttondown", &event::mousebuttondown, false)
 		.addVariable("mousebuttonup", &event::mousebuttonup, false)
 		.addVariable("mousewheel", &event::mousewheel, false)
+		.addVariable("textinput", &event::textinput, false)
 		.endNamespace()
 
 		.beginNamespace("mouse")

--- a/sdl-utils.cpp
+++ b/sdl-utils.cpp
@@ -769,6 +769,10 @@ int Event::wheely() {
 int Event::keycode() {
 	return event.key.keysym.sym;
 }
+int Event::textinput(lua_State* L) {
+	lua_pushstring(L, event.text.text);
+	return 1;
+}
 
 
 

--- a/sdl-utils.h
+++ b/sdl-utils.h
@@ -10,6 +10,7 @@
 #include "Gdiplus.h"
 
 #include "blob.h"
+#include "lua.h"
 
 #include "glew/glew.h"
 #include <GL/GL.h>
@@ -187,6 +188,7 @@ struct Event {
 
 	int wheely();
 	int keycode();
+	int textinput(lua_State* L);
 };
 
 struct EventHook {


### PR DESCRIPTION
## C++
Adds the function:
`int Event::textinput(lua_State* L)`

I added this to the sdl event class using `addCFunction` as opposed to `addFunction` as I needed it to return a string. I am unsure of the syntax needed (if possible) to get the function to return a string, when adding it with `addFunction`.

## Lua
On the lua side, this adds the event type `sdl.events.textinput`.
This event returns the character being pressed with `event:textinput()`.

Using this event, it will be possible to create input fields where we can write custom text while in game.