### PR TITLE
Trim text surfaces

### DIFF
--- a/lua-functions.cc
+++ b/lua-functions.cc
@@ -199,6 +199,8 @@ void installFunctions(lua_State *L) {
 		.addConstructor <void(*) (const std::string & s)>()
 		.addFunction("w", &SDL::Surface::w)
 		.addFunction("h", &SDL::Surface::h)
+		.addFunction("padl", &SDL::Surface::leftPadding)
+		.addFunction("padr", &SDL::Surface::rightPadding)
 		.addData("x", &SDL::Surface::x, false)
 		.addData("y", &SDL::Surface::y, false)
 		.addFunction("wasDrawn", &SDL::Surface::wasDrawn)

--- a/sdl-utils.cpp
+++ b/sdl-utils.cpp
@@ -373,6 +373,11 @@ Surface::Surface(const Font * font, const TextSettings *settings, const std::str
 	Gdiplus::Bitmap bitmap((int) ceil(boundRect.Width), (int) ceil(boundRect.Height), PixelFormat32bppARGB);
 	Gdiplus::Graphics *g = Gdiplus::Graphics::FromImage(&bitmap);
 
+	g->SetTextRenderingHint(antialias ?
+		Gdiplus::TextRenderingHintAntiAlias :
+		Gdiplus::TextRenderingHintSingleBitPerPixelGridFit
+	);
+
 	Gdiplus::SolidBrush redbrush(Gdiplus::Color::Red);
 	g->DrawString(s.c_str(), -1, *font, Gdiplus::PointF(0, 0), &redbrush);
 

--- a/sdl-utils.h
+++ b/sdl-utils.h
@@ -83,6 +83,7 @@ struct Surface {
 	unsigned long long hash;
 	int width, height;
 	double x, y;
+	int padl, padr;
 
 	void setBitmap(Gdiplus::Bitmap *bitmap);
 	void setBitmap(HBITMAP hbitmap, int x, int y, int w, int h);
@@ -106,6 +107,14 @@ struct Surface {
 
 	int h() {
 		return height;
+	}
+
+	int leftPadding() {
+		return padl;
+	}
+
+	int rightPadding() {
+		return padr;
 	}
 
 	bool wasDrawn();


### PR DESCRIPTION
The code in this PR changes lua function `sdl.text` so that the returned surface does not contain leading or trailing empty pixels.

The intent is to be able to string together surfaces of single characters to create fully dynamic text boxes. JustinFont, used in Into the Breach does not have characters that hang over or under the previous or next character, making it suitable for this purpose.

As a result of this PR, all current text (in mod loader and mods) that is left or right aligned, will be shifted slightly.
additional variables `padl` and `padr` has been added to surfaces which contains the widths of the removed pixels. This addition could maybe be removed if they are not needed after all.