### PR TITLE
Added Rect.contains and Rect.intersects

### DIFF
--- a/lua-functions.cc
+++ b/lua-functions.cc
@@ -283,6 +283,8 @@ void installFunctions(lua_State *L) {
 		.addData("y", &SDL::Rect::y)
 		.addData("w", &SDL::Rect::w)
 		.addData("h", &SDL::Rect::h)
+		.addFunction("contains", &SDL::Rect::contains)
+		.addFunction("intersects", &SDL::Rect::intersects)
 		.addFunction("getIntersect", &SDL::Rect::getIntersect)
 		.addFunction("getUnion", &SDL::Rect::getUnion)
 		.endClass()

--- a/sdl-utils.cpp
+++ b/sdl-utils.cpp
@@ -93,6 +93,15 @@ Rect::Rect(int x, int y, int w, int h) {
 	this->h = h;
 }
 
+bool Rect::contains(int x, int y) {
+	SDL_Point p = { x, y };
+	return SDL_PointInRect(&p, this);
+}
+
+bool Rect::intersects(Rect* other) {
+	return SDL_HasIntersection(this, other);
+}
+
 Rect Rect::getIntersect(Rect* other) {
 	Rect* result;
 	if (SDL_IntersectRect(this, other, result)) {

--- a/sdl-utils.h
+++ b/sdl-utils.h
@@ -29,6 +29,8 @@ struct Color :public SDL_Color {
 
 struct Rect :public SDL_Rect {
 	Rect(int x, int y, int w, int h);
+	bool contains(int x, int y);
+	bool intersects(Rect*);
 	Rect getIntersect(Rect*);
 	Rect getUnion(Rect*);
 };


### PR DESCRIPTION
When trying to solve the bugs introduced to the ui in the ITB mod loader, I kept running into slowdown from the mod loader's `rect_contains` function. Using SDL rectangle functions instead of doing the math in lua appear to be much faster, and could help in fixing said bugs.