### PR TITLE
Feature/mask

### DIFF
--- a/lua-functions.cc
+++ b/lua-functions.cc
@@ -145,6 +145,8 @@ void installFunctions(lua_State *L) {
 
 		.beginClass <SDL::Color>("color")
 		.addStaticData("white", &SDL::Color::White, false)
+		.addStaticData("black", &SDL::Color::Black, false)
+		.addStaticData("transparent", &SDL::Color::Transparent, false)
 		.addData("r", &SDL::Color::r)
 		.addData("g", &SDL::Color::g)
 		.addData("b", &SDL::Color::b)

--- a/lua-functions.cc
+++ b/lua-functions.cc
@@ -252,6 +252,9 @@ void installFunctions(lua_State *L) {
 		.addFunction("drawrect", &SDL::Screen::drawrect)
 		.addFunction("clip", &SDL::Screen::clip)
 		.addFunction("unclip", &SDL::Screen::unclip)
+		.addFunction("mask", &SDL::Screen::mask)
+		.addFunction("unmask", &SDL::Screen::unmask)
+		.addFunction("clearmask", &SDL::Screen::clearmask)
 		.addFunction("getClipRect", &SDL::Screen::getClipRect)
 		.endClass()
 

--- a/sdl-utils.cpp
+++ b/sdl-utils.cpp
@@ -813,6 +813,9 @@ void Screen::unmask(size_t count) {
 	glStencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
 	glStencilFunc(GL_EQUAL, 0, 0xFF);
 	glStencilMask(0x00);
+
+	if (maskRects.empty())
+		glDisable(GL_STENCIL_TEST);
 }
 
 void Screen::clearmask() {

--- a/sdl-utils.cpp
+++ b/sdl-utils.cpp
@@ -85,6 +85,8 @@ Color::Color(int r, int g, int b) {
 }
 
 Color Color::White = Color();
+Color Color::Black = Color(0, 0, 0);
+Color Color::Transparent = Color(0, 0, 0, 0);
 
 Rect::Rect(int x, int y, int w, int h) {
 	this->x = x;

--- a/sdl-utils.cpp
+++ b/sdl-utils.cpp
@@ -799,7 +799,7 @@ void Screen::unmask(size_t count) {
 	glEnable(GL_STENCIL_TEST);
 
 	glStencilOp(GL_KEEP, GL_KEEP, GL_DECR);
-	glStencilFunc(GL_GEQUAL, 1, 0xFF);
+	glStencilFunc(GL_ALWAYS, 1, 0xFF);
 	glStencilMask(0xFF);
 
 	while (count-- > 0 && !maskRects.empty()) {

--- a/sdl-utils.cpp
+++ b/sdl-utils.cpp
@@ -799,7 +799,7 @@ void Screen::unmask(size_t count) {
 	glEnable(GL_STENCIL_TEST);
 
 	glStencilOp(GL_KEEP, GL_KEEP, GL_DECR);
-	glStencilFunc(GL_GREATER, 1, 0xFF);
+	glStencilFunc(GL_GEQUAL, 1, 0xFF);
 	glStencilMask(0xFF);
 
 	while (count-- > 0 && !maskRects.empty()) {

--- a/sdl-utils.cpp
+++ b/sdl-utils.cpp
@@ -819,8 +819,8 @@ void Screen::unmask(size_t count) {
 }
 
 void Screen::clearmask() {
-	glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
-	glStencilFunc(GL_ALWAYS, 1, 0xFF);
+	glStencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
+	glStencilFunc(GL_ALWAYS, 0, 0xFF);
 	glStencilMask(0xFF);
 
 	maskRects.clear();

--- a/sdl-utils.h
+++ b/sdl-utils.h
@@ -22,6 +22,8 @@ GLuint glTexture(unsigned char *pixelData, int w, int h);
 
 struct Color :public SDL_Color {
 	static Color White;
+	static Color Black;
+	static Color Transparent;
 	Color();
 	Color(int r, int g, int b, int a);
 	Color(int r, int g, int b);

--- a/sdl-utils.h
+++ b/sdl-utils.h
@@ -150,6 +150,7 @@ struct SurfaceScreenshot :public Surface {
 struct Screen {
 	SDL_Window* window;
 	std::vector<Rect> clippingRects;
+	std::vector<Rect> maskRects;
 
 	Screen();
 
@@ -176,6 +177,9 @@ struct Screen {
 	void drawrect(Color *color, Rect *rect);
 	void clip(Rect *rect);
 	void unclip();
+	void mask(Rect *rect);
+	void unmask(size_t count);
+	void clearmask();
 	Rect* getClipRect();
 
 protected:


### PR DESCRIPTION
### Colors:
- `sdl.color.transparent` - static entry for `sdl.rgba(0,0,0,0)`
- `sdl.color.black` - static entry for `sdl.rgba(0,0,0,255)`

### Functions:
- `screen:mask(sdl.rect)` - "draws" an invisible rectangle to the screen. Any further draw calls will not be drawn in this rectangle until `unmask` has been called.
- `screen:unmask(n)` - clears the n last masks, allowing those rectangles to be drawn to again (unless additional uncleared masks are still covering those areas).
- `screen:clearmask()` - clears all masks, allowing the entire screen to be drawn to again. Ideal for the start of a draw call.