### PR TITLE
Update os.listall, os.listfiles and os.listdirs

### DIFF
--- a/lua-functions.cc
+++ b/lua-functions.cc
@@ -28,9 +28,9 @@ int listDirectoryFull(lua_State *L, int mode) {
 	std::string path;
 
 	if (!std::regex_match(dirname, startsWithDriveLetter))
-		path = regex_replace(dirname, fullPath, ".\\$1\\*.*");
+		path = format(".\\%s\\*.*", dirname);
 	else
-		path = regex_replace(dirname, fullPath, "$1\\*.*");
+		path = format("%s\\*.*", dirname);
 		
 	if((handle = FindFirstFileA(path.c_str(), &fdFile)) == INVALID_HANDLE_VALUE) {
 		return 1;

--- a/lua-functions.cc
+++ b/lua-functions.cc
@@ -14,17 +14,23 @@ using namespace luabridge;
 #include <regex>
 
 int listDirectoryFull(lua_State *L, int mode) {
-	const char *dirname = lua_tostring(L, 1);
-
 	lua_newtable(L);
+
+	if (!lua_isstring(L, 1))
+		return 1;
+
+	const char *dirname = lua_tostring(L, 1);
 
 	WIN32_FIND_DATAA fdFile;
 	HANDLE handle = NULL;
+	std::regex fullPath("(.*)");
 	std::regex startsWithDriveLetter("^.:.*$");
-	std::string path = format("%s\\*.*", dirname);
+	std::string path;
 
-	if (!std::regex_match(path, startsWithDriveLetter))
-		path = format(".\\%s", path);
+	if (!std::regex_match(dirname, startsWithDriveLetter))
+		path = regex_replace(dirname, fullPath, ".\\$1\\*.*");
+	else
+		path = regex_replace(dirname, fullPath, "$1\\*.*");
 		
 	if((handle = FindFirstFileA(path.c_str(), &fdFile)) == INVALID_HANDLE_VALUE) {
 		return 1;

--- a/lua-functions.cc
+++ b/lua-functions.cc
@@ -11,6 +11,7 @@ using namespace luabridge;
 #include "SDL_syswm.h"
 #include <vector>
 #include <algorithm>
+#include <regex>
 
 int listDirectoryFull(lua_State *L, int mode) {
 	const char *dirname = lua_tostring(L, 1);
@@ -19,8 +20,12 @@ int listDirectoryFull(lua_State *L, int mode) {
 
 	WIN32_FIND_DATAA fdFile;
 	HANDLE handle = NULL;
+	std::regex startsWithDriveLetter("^.:.*$");
+	std::string path = format("%s\\*.*", dirname);
 
-	std::string path = format(".\\%s\\*.*", dirname);
+	if (!std::regex_match(path, startsWithDriveLetter))
+		path = format(".\\%s", path);
+		
 	if((handle = FindFirstFileA(path.c_str(), &fdFile)) == INVALID_HANDLE_VALUE) {
 		return 1;
 	}

--- a/lua-functions.cc
+++ b/lua-functions.cc
@@ -23,7 +23,6 @@ int listDirectoryFull(lua_State *L, int mode) {
 
 	WIN32_FIND_DATAA fdFile;
 	HANDLE handle = NULL;
-	std::regex fullPath("(.*)");
 	std::regex startsWithDriveLetter("^.:.*$");
 	std::string path;
 


### PR DESCRIPTION
# Changes
- Update functions to both accept fixed paths starting with a drive letter, while at the same time keeping their current functionality exactly the same as before.

# Examples

## Same behavior as before:
- `os.listdirs("")` will still list all directories in the Into the Breach directory.
- `os.listdirs("mods")` will still list all directories in the Into the Breach mods directory.

## New capabilities:
- `os.listdirs("C:")` will list all directories in the C directory.
- `os.listdirs("D:")` will list all directories in the D directory.
- `os.listdirs(GetSavedataLocation())` will list all directories in the Into the Breach save directory.

# Why not use io.popen or os.execute instead?
- Listing files and directories using io.popen or os.execute causes a program to briefly open, which can cause flickering issues which negatively impact the player experience.